### PR TITLE
fix: import nuxt composables from #imports

### DIFF
--- a/plugins/sortable.client.ts
+++ b/plugins/sortable.client.ts
@@ -1,4 +1,4 @@
-import { defineNuxtPlugin } from '#app'
+import { defineNuxtPlugin } from '#imports'
 import { Sortable } from 'sortablejs-vue3'
 
 export default defineNuxtPlugin((nuxtApp) => {


### PR DESCRIPTION
This is a DX improvement when developing - we can avoid loading the entire barrel file at `#app` by using the new granular imports merged in https://github.com/nuxt/nuxt/pull/23951.